### PR TITLE
Fix CI: replace removed ubuntu-18.04 runner and bazel build with cmake

### DIFF
--- a/.github/workflows/config.rb
+++ b/.github/workflows/config.rb
@@ -7,5 +7,6 @@ MRuby::Build.new do |conf|
   conf.cxx.flags << '-fsanitize=address,undefined'
   conf.linker.flags << '-fsanitize=address,undefined'
 
+  conf.gem :core => 'mruby-compiler'
   conf.gem "#{MRUBY_ROOT}/.."
 end

--- a/.github/workflows/mrbgem.yml
+++ b/.github/workflows/mrbgem.yml
@@ -5,28 +5,42 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  TFLITE_VERSION: 2.16.2
+
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
-        mruby_version: [master, 2.1.2, 1.4.1]
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} & mruby-${{ matrix.mruby_version }}
+        mruby_version: [master, 3.3.0]
+    runs-on: ubuntu-latest
+    name: ubuntu-latest & mruby-${{ matrix.mruby_version }}
     env:
       MRUBY_VERSION: ${{ matrix.mruby_version }}
     steps:
-    - uses: actions/checkout@v2
-    - name: install package
+    - uses: actions/checkout@v4
+    - name: cache tensorflow lite
+      id: cache-tflite
+      uses: actions/cache@v4
+      with:
+        path: tflite
+        key: tflite-${{ env.TFLITE_VERSION }}
+    - name: build tensorflow lite C library
+      if: steps.cache-tflite.outputs.cache-hit != 'true'
       run: |
-        sudo apt install curl gnupg
-        curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-        sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-        echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        sudo apt update && sudo apt install bazel bazel-3.1.0 python-pip python-dev libegl1-mesa-dev libgles2-mesa-dev
-        sudo pip install numpy future
+        git clone --depth 1 -b v$TFLITE_VERSION https://github.com/tensorflow/tensorflow.git tensorflow-src
+        cmake -S tensorflow-src/tensorflow/lite/c -B tflite-build \
+          -DCMAKE_BUILD_TYPE=Release -DTFLITE_ENABLE_XNNPACK=OFF
+        cmake --build tflite-build -j$(nproc) -t tensorflowlite_c
+        mkdir -p tflite/tensorflow/lite/experimental/c
+        cp tflite-build/libtensorflowlite_c.so tflite/tensorflow/lite/experimental/c/
+        rsync -a --include='*/' --include='*.h' --exclude='*' tensorflow-src/tensorflow/ tflite/tensorflow/
     - name: download mruby
       run: git clone --depth 1 -b $MRUBY_VERSION "https://github.com/mruby/mruby.git" mruby
     - name: run test
+      env:
+        TENSORFLOW_ROOT: ${{ github.workspace }}/tflite/
+        LD_LIBRARY_PATH: ${{ github.workspace }}/tflite/tensorflow/lite/experimental/c
+        ASAN_OPTIONS: detect_leaks=0
       run: cd mruby && MRUBY_CONFIG="../.github/workflows/config.rb" ./minirake all test

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,8 +3,7 @@ MRuby::Gem::Specification.new('mruby-tflite') do |spec|
   spec.authors = 'mattn'
   spec.version = '2.3.0'
 
-  add_test_dependency 'mruby-env'
-  ENV['MRB_TFLITE_XORMODEL'] = "#{dir}/test/xor_model.tflite"
+  spec.test_args = { 'model' => "#{dir}/test/xor_model.tflite" }
 
   if ENV['TENSORFLOW_ROOT']
     spec.cc.include_paths << ENV['TENSORFLOW_ROOT']

--- a/src/mrb_tflite.c
+++ b/src/mrb_tflite.c
@@ -300,7 +300,7 @@ mrb_tflite_tensor_data_get(mrb_state *mrb, mrb_value self) {
     default:
       mrb_raisef(mrb, E_RUNTIME_ERROR, "tensor type %S not supported", mrb_str_new_cstr(mrb, tensor_type_name(type)));
   }
-  MRB_SET_FROZEN_FLAG(mrb_basic_ptr(ret));
+  mrb_obj_freeze(mrb, ret);
   return ret;
 }
 

--- a/test/tflite_test.rb
+++ b/test/tflite_test.rb
@@ -1,5 +1,5 @@
 assert('xor') do
-  model = TfLite::Model.from_file(ENV['MRB_TFLITE_XORMODEL'])
+  model = TfLite::Model.from_file(TEST_ARGS['model'])
   interpreter = TfLite::Interpreter.new(model)
   interpreter.allocate_tensors
   input = interpreter.input_tensor(0)


### PR DESCRIPTION
The workflow targeted the ubuntu-18.04 runner, which GitHub Actions no longer provides, and built TensorFlow 2.3 with bazel, which no longer works. Build the TensorFlow Lite C library with cmake on ubuntu-latest and cache it, and test against mruby master and 3.3.0.