### PR TITLE
Check tensor index bounds in input_tensor and output_tensor

### DIFF
--- a/src/mrb_tflite.c
+++ b/src/mrb_tflite.c
@@ -205,6 +205,9 @@ mrb_tflite_interpreter_input_tensor(mrb_state *mrb, mrb_value self) {
   mrb_value c;
   TfLiteInterpreter* interpreter = DATA_PTR(self);
   mrb_get_args(mrb, "i", &index);
+  if (index < 0 || index >= TfLiteInterpreterGetInputTensorCount(interpreter)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "index out of range");
+  }
   tensor = TfLiteInterpreterGetInputTensor(interpreter, index);
   if (tensor == NULL) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument");
@@ -224,7 +227,13 @@ mrb_tflite_interpreter_output_tensor(mrb_state *mrb, mrb_value self) {
   mrb_value c;
   TfLiteInterpreter* interpreter = DATA_PTR(self);
   mrb_get_args(mrb, "i", &index);
+  if (index < 0 || index >= TfLiteInterpreterGetOutputTensorCount(interpreter)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "index out of range");
+  }
   tensor = (TfLiteTensor*) TfLiteInterpreterGetOutputTensor(interpreter, index);
+  if (tensor == NULL) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument");
+  }
   _class_tflite_tensor = mrb_class_get_under(mrb, mrb_module_get(mrb, "TfLite"), "Tensor");
   c = mrb_obj_new(mrb, _class_tflite_tensor, 0, NULL);
   DATA_TYPE(c) = &mrb_tflite_tensor_type_;

--- a/test/tflite_test.rb
+++ b/test/tflite_test.rb
@@ -10,3 +10,13 @@ assert('xor') do
     assert_equal(x[0] ^ x[1], output.data[0].round)
   end
 end
+
+assert('tensor index out of range') do
+  model = TfLite::Model.from_file(TEST_ARGS['model'])
+  interpreter = TfLite::Interpreter.new(model)
+  interpreter.allocate_tensors
+  assert_raise(ArgumentError) { interpreter.input_tensor(100) }
+  assert_raise(ArgumentError) { interpreter.input_tensor(-1) }
+  assert_raise(ArgumentError) { interpreter.output_tensor(100) }
+  assert_raise(ArgumentError) { interpreter.output_tensor(-1) }
+end


### PR DESCRIPTION
TfLiteInterpreterGetInputTensor/GetOutputTensor index into the inputs/outputs vector without bounds checking, so an out-of-range index is undefined behavior. output_tensor also lacked the NULL check that input_tensor had. Validate the index against the tensor count and raise ArgumentError.