### PR TITLE
Check dim index bounds in Tensor#dim

### DIFF
--- a/src/mrb_tflite.c
+++ b/src/mrb_tflite.c
@@ -281,6 +281,9 @@ mrb_tflite_tensor_dim(mrb_state *mrb, mrb_value self) {
   TfLiteTensor* tensor = mrb_data_get_ptr(mrb, self, &mrb_tflite_tensor_type_);
   mrb_int index;
   mrb_get_args(mrb, "i", &index);
+  if (index < 0 || index >= TfLiteTensorNumDims(tensor)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "index out of range");
+  }
   return mrb_fixnum_value(TfLiteTensorDim(tensor, index));
 }
 

--- a/test/tflite_test.rb
+++ b/test/tflite_test.rb
@@ -19,6 +19,9 @@ assert('tensor index out of range') do
   assert_raise(ArgumentError) { interpreter.input_tensor(-1) }
   assert_raise(ArgumentError) { interpreter.output_tensor(100) }
   assert_raise(ArgumentError) { interpreter.output_tensor(-1) }
+  input = interpreter.input_tensor(0)
+  assert_raise(ArgumentError) { input.dim(100) }
+  assert_raise(ArgumentError) { input.dim(-1) }
 end
 
 assert('invalid arguments raise') do


### PR DESCRIPTION
TfLiteTensorDim reads dims->data[index] without bounds checking, so an out-of-range index read out of bounds. Validate the index against TfLiteTensorNumDims and raise ArgumentError.